### PR TITLE
Fix incorrect host on 307 redirect

### DIFF
--- a/R/curl_webhdfs.R
+++ b/R/curl_webhdfs.R
@@ -23,6 +23,9 @@ curl_webhdfs <- function(webhdfs, url, requestType = c("GET","POST","PUT","DELET
       url <- paste0(get_webhdfs_home(webhdfs, doas), "/", url)
     url <- paste0("http://",webhdfs$host,":",webhdfs$port,"/webhdfs/v1",url)
   }
+  if(webhdfs$host != "localhost" && grepl("^http://localhost:", url)){
+    url <- sub("^http://localhost:", paste0("http://", webhdfs$host, ":"), url)
+  }
   if(webhdfs$security && isTRUE(nzchar(webhdfs$token)))
     url <- paste0(url,"&token=",webhdfs$token)
   if(isTRUE(nzchar(webhdfs$user)))


### PR DESCRIPTION
RCurl::basicHeaderGatherer() returns a 307 redirect location with "localhost" as the host even when webhdfs$host is not "localhost". This code checks for that condition and replaces "localhost" with the original host.