### PR TITLE
Change handling of ... argument of curl_webhdfs

### DIFF
--- a/R/curl_webhdfs.R
+++ b/R/curl_webhdfs.R
@@ -34,7 +34,6 @@ curl_webhdfs <- function(webhdfs, url, requestType = c("GET","POST","PUT","DELET
     url <- paste0(url,"&doas=",doas)
   
   opts <- if(inherits(.opts, "curlOptions")) .opts else curlOptions()
-  opts <- curlOptions(..., .opts=opts)
   #Enable Kerberos SPNEGO
   if(webhdfs$security && is.null(webhdfs$token))
       opts[["username"]] <- ":"
@@ -61,7 +60,7 @@ curl_webhdfs <- function(webhdfs, url, requestType = c("GET","POST","PUT","DELET
                         upload = TRUE, .opts=opts)
   }
   
-  response <- getURL(url, .opts=opts)
+  response <- getURL(url, .opts=opts, ...)
   
   if(as.integer(h$value()["status"]) >= 400)
     stop("Request failed: ", h$value()["statusMessage"],


### PR DESCRIPTION
According to the documentation the ... argument in curl_webhdfs should be passed
to getURL but the code actually passed it to curlOptions.
This makes it impossible the use the getURL options like .encoding or .mapUnicode.

I needed one of those options to enforce the correct encoding in a request that
was not handling the encoding correctly.